### PR TITLE
Fix typo in linux_build-default.bash

### DIFF
--- a/linux_build-default.bash
+++ b/linux_build-default.bash
@@ -2,6 +2,6 @@
 
 set -ex
 
-export CMAKE_ARGS="-DBUILD_TEST=ON -DBUILD_DEMO=ON $MAKE_ARGS"
+export CMAKE_ARGS="-DBUILD_TEST=ON -DBUILD_DEMO=ON $CMAKE_ARGS"
 
 bash linux_build.bash


### PR DESCRIPTION
xref https://github.com/kostrykin/LibCarna/commit/ae63a7286049ecad411a3e86fd4f04a17f394fd8#r157369698